### PR TITLE
성문/5월 1주차

### DIFF
--- a/BOJ/01764.cpp
+++ b/BOJ/01764.cpp
@@ -1,0 +1,26 @@
+#include <bits/stdc++.h>
+namespace ran = std::ranges;
+using namespace std;
+using ll = long long;
+
+int main() {
+    ios_base::sync_with_stdio(false); cin.tie(nullptr); cout.tie(nullptr);
+
+    int N, M; cin >> N >> M;
+
+    string tmp;
+    unordered_map<string, int> mp;
+    for (int i = 0; i < N+M; i++) {
+        cin >> tmp;
+        mp[tmp]++;
+    }
+
+    vector<string> vs;
+    for (const auto& [k, v] : mp) {
+        if (v == 2) vs.push_back(k);
+    }
+    ran::sort(vs); // std::sort(vs.begin(), vs.end());
+
+    cout << vs.size() << '\n';
+    for (const auto& it : vs) cout << it << '\n';
+}

--- a/BOJ/02559.cpp
+++ b/BOJ/02559.cpp
@@ -1,0 +1,20 @@
+#include <bits/stdc++.h>
+namespace ran = std::ranges;
+using namespace std;
+using ll = long long;
+
+int main() {
+    ios_base::sync_with_stdio(false); cin.tie(nullptr); cout.tie(nullptr);
+
+    int N, K; cin >> N >> K;
+    vector<int> vi(N);
+    for (int i = 0; i < N; i++) cin >> vi[i];
+
+    int fr = 0, rr = K;
+    vector<int> res;
+    while (rr <= N) {
+        res.push_back(reduce(&vi[fr], &vi[rr]));
+        fr++, rr++;
+    }
+    cout << ran::max(res); // std::ranges::max();
+}

--- a/BOJ/11728.cpp
+++ b/BOJ/11728.cpp
@@ -1,0 +1,29 @@
+#include <bits/stdc++.h>
+namespace ran = std::ranges;
+using namespace std;
+using ll = long long;
+
+constexpr int MAX = 2'147'483'647;
+
+int main() {
+    ios_base::sync_with_stdio(false); cin.tie(nullptr); cout.tie(nullptr);
+
+    int N, M; cin >> N >> M; // N: 배열 A 크기, M: 배열 B 크기
+    vector<int> vi1(N), vi2(M);
+    for (int i = 0; i < N; i++) cin >> vi1[i];
+    for (int i = 0; i < M; i++) cin >> vi2[i];
+    vi1.push_back(MAX), vi2.push_back(MAX); // 포인터가 끝에 도달하면 무조건 반대편에서 꺼내도록
+
+    vector<int> res;
+    int pt1 = 0, pt2 = 0; // 투 포인터
+    while (pt1 < N || pt2 < M) {
+        if (vi1[pt1] < vi2[pt2]) {
+            res.push_back(vi1[pt1]);
+            pt1++;
+        } else {
+            res.push_back(vi2[pt2]);
+            pt2++;
+        }
+    }
+    for (int it : res) cout << it << ' ';
+}


### PR DESCRIPTION
## 배열 합치기 / 실버5 / 정렬, 두 포인터

- 입력:  

첫째 줄에 배열 A의 크기 N, 배열 B의 크기 M이 주어진다. (1 ≤ N, M ≤ 1,000,000)

둘째 줄에는 배열 A의 내용이, 셋째 줄에는 배열 B의 내용이 주어진다. 배열에 들어있는 수는 절댓값이 1e9보다 작거나 같은 정수이다.
- 출력:  

첫째 줄에 두 배열을 합친 후 정렬한 결과를 출력한다.

- 풀이:  

N: 배열 A 크기, M: 배열 B 크기. 배열의 원소들을 입력받은 다음, 배열의 마지막 원소로 int형 최대값을 넣어 조건 처리를 단순화하고, 포인터가 끝에 도달하면 무조건 반대편에서 꺼낼 수 있도록 했습니다.